### PR TITLE
Changing the master/slave lingo

### DIFF
--- a/django_gii_pcmark/admin/dicts.py
+++ b/django_gii_pcmark/admin/dicts.py
@@ -55,8 +55,8 @@ class MBPowerSchemasAdmin(admin.ModelAdmin):
     """
     админка для схемы питания матринских плат
     """
-    ordering = ('main', 'slave')
-    list_display = ('main', 'slave')
+    ordering = ('main', 'subordinate')
+    list_display = ('main', 'subordinate')
 
 
 class DDRVersionDictAdmin(admin.ModelAdmin):

--- a/django_gii_pcmark/migrations/0001_initial.py
+++ b/django_gii_pcmark/migrations/0001_initial.py
@@ -176,7 +176,7 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
                 ('main', models.PositiveSmallIntegerField()),
-                ('slave', models.PositiveSmallIntegerField()),
+                ('subordinate', models.PositiveSmallIntegerField()),
             ],
             options={
                 'verbose_name_plural': 'Справочник: схема питания материнских плат',

--- a/django_gii_pcmark/models/dicts.py
+++ b/django_gii_pcmark/models/dicts.py
@@ -218,13 +218,13 @@ class MBPowerSchemas(models.Model):
     """
 
     main = models.PositiveSmallIntegerField()
-    slave = models.PositiveSmallIntegerField()
+    subordinate = models.PositiveSmallIntegerField()
 
     def __str__(self):
         """
         строковое представление объекта
         """
-        return '{0} x {1}'.format(self.main, self.slave)
+        return '{0} x {1}'.format(self.main, self.subordinate)
 
     class Meta:
         """


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.